### PR TITLE
Organized resolvers

### DIFF
--- a/server/src/graphql-api/__tests__/server.test.ts
+++ b/server/src/graphql-api/__tests__/server.test.ts
@@ -1,7 +1,7 @@
 import { gql } from "apollo-server";
 import { createTestClient } from "apollo-server-testing";
 import { Client, SearchResponse, SearchParams } from "elasticsearch";
-import { server } from "../server";
+import { createServer } from "../createServer";
 
 const SPACE_MUSEUM_QUERY = gql`
   {
@@ -90,7 +90,7 @@ jest.mock("elasticsearch", () => ({
   }
 }));
 
-const { query } = createTestClient(server);
+const { query } = createTestClient(createServer({ esClient: new Client({}) }));
 
 describe("museums query", () => {
   it("returns a MuseumConnection", async () => {

--- a/server/src/graphql-api/createServer.ts
+++ b/server/src/graphql-api/createServer.ts
@@ -1,0 +1,17 @@
+import { ApolloServer } from "apollo-server";
+import { Client } from "elasticsearch";
+import { resolvers } from "./resolvers";
+import { typeDefs } from "./typeDefs";
+import { ResolverContext } from "./types";
+
+interface CreateServerParams {
+  esClient: Client;
+}
+
+export function createServer({ esClient }: CreateServerParams) {
+  return new ApolloServer({
+    typeDefs,
+    resolvers,
+    context: { esClient } as ResolverContext
+  });
+}

--- a/server/src/graphql-api/resolvers.ts
+++ b/server/src/graphql-api/resolvers.ts
@@ -1,32 +1,9 @@
-import { Client } from "elasticsearch";
 import { IResolvers } from "graphql-tools";
+import { museums } from "./resolvers/museums";
+import { ResolverContext } from "./types";
 
-const esClient = new Client({
-  host: process.env.ES_HOST
-})
-
-export const resolvers: IResolvers<{}, {}> = {
+export const resolvers: IResolvers<{}, ResolverContext> = {
   Query: {
-    museums: async (source, args) => {
-      const { hits } = await esClient.search({
-        index: "museums",
-        size: args.first || 100,
-        body: {
-          query: {
-            multi_match: {
-              query: args.query
-            }
-          }
-        }
-      });
-
-      return {
-        edges: hits.hits.map(hit => ({
-          node: hit._source,
-          cursor: hit._id
-        })),
-        count: hits.total
-      };
-    }
+    museums
   }
 };

--- a/server/src/graphql-api/resolvers/museums.ts
+++ b/server/src/graphql-api/resolvers/museums.ts
@@ -1,0 +1,28 @@
+import { IFieldResolver } from "graphql-tools";
+import { ResolverContext } from "../types";
+
+export const museums: IFieldResolver<{}, ResolverContext> = async (
+  _,
+  args,
+  { esClient }
+) => {
+  const { hits } = await esClient.search({
+    index: "museums",
+    size: args.first || 100,
+    body: {
+      query: {
+        multi_match: {
+          query: args.query
+        }
+      }
+    }
+  });
+
+  return {
+    edges: hits.hits.map(hit => ({
+      node: hit._source,
+      cursor: hit._id
+    })),
+    count: hits.total
+  };
+};

--- a/server/src/graphql-api/server.ts
+++ b/server/src/graphql-api/server.ts
@@ -1,8 +1,0 @@
-import { ApolloServer } from "apollo-server";
-import { resolvers } from "./resolvers";
-import { typeDefs } from "./typeDefs";
-
-export const server = new ApolloServer({
-  typeDefs,
-  resolvers
-});

--- a/server/src/graphql-api/types.ts
+++ b/server/src/graphql-api/types.ts
@@ -1,0 +1,5 @@
+import { Client } from "elasticsearch";
+
+export interface ResolverContext {
+  esClient: Client;
+}

--- a/server/src/scripts/launch-graphql-api.ts
+++ b/server/src/scripts/launch-graphql-api.ts
@@ -1,8 +1,15 @@
-require('dotenv').config();
+require("dotenv").config();
 
-import { server } from "../graphql-api/server";
+import { createServer } from "../graphql-api/createServer";
+import { Client } from "elasticsearch";
+
+const esClient = new Client({
+  host: process.env.ES_HOST
+});
 
 // Start server.
-server.listen().then(({ url }) => {
-  console.log(`GraphQL API ready at ${url}`);
-});
+createServer({ esClient })
+  .listen()
+  .then(({ url }) => {
+    console.log(`GraphQL API ready at ${url}`);
+  });


### PR DESCRIPTION
-Changed server object export to createServer function export.
-Created graphql context containing the elasticsearch client.
-Moved museum resolver into a separate file.