### PR TITLE
museum-list-scrolling

### DIFF
--- a/packages/client/pages/__tests__/__snapshots__/index.test.tsx.snap
+++ b/packages/client/pages/__tests__/__snapshots__/index.test.tsx.snap
@@ -2,7 +2,7 @@
 
 exports[`MuseumSearchPage component Shallow renders.: MuseumSearchPage shallow render. 1`] = `
 <div
-  className="container-fluid p-0 d-flex flex-column flex-fill"
+  className="container-fluid"
 >
   <style>
     
@@ -11,8 +11,6 @@ exports[`MuseumSearchPage component Shallow renders.: MuseumSearchPage shallow r
     height: 100%;
   }
   #__next {
-    display: flex;
-    flex-flow: column;
     height: 100%;
   }
 
@@ -20,23 +18,19 @@ exports[`MuseumSearchPage component Shallow renders.: MuseumSearchPage shallow r
   <Head
     title="Museum Search"
   />
-  <div
-    className="flex-shrink-0"
-  >
-    <h1
-      className="col-12"
-    >
+  <div>
+    <h1>
       Museum Search
     </h1>
   </div>
   <div
-    className="d-flex flex-row h-100"
+    className="row"
   >
     <div
-      className="d-flex flex-column flex-grow-1 card"
+      className="col-md-3 p-0 card"
     >
       <div
-        className="card-body flex-grow-0"
+        className="card-body"
       >
         <Formik
           enableReinitialize={false}
@@ -61,6 +55,7 @@ exports[`MuseumSearchPage component Shallow renders.: MuseumSearchPage shallow r
         </Formik>
       </div>
       <div
+        className="list-container"
         style={
           Object {
             "overflowY": "scroll",

--- a/packages/client/pages/__tests__/index.test.tsx
+++ b/packages/client/pages/__tests__/index.test.tsx
@@ -1,5 +1,6 @@
-import { shallow } from "enzyme";
+import { mount, shallow } from "enzyme";
 import { Formik } from "formik";
+import { MockedProvider } from "react-apollo/test-utils";
 import { MuseumList } from "../../components/search/MuseumList";
 import { MuseumSearchPage } from "../index";
 
@@ -31,7 +32,7 @@ describe("MuseumSearchPage component", () => {
     });
   });
 
-  it("Performs a bounding-box search when the map is moved.", async () => {
+  it("Performs a bounding-box search when the map is moved.", () => {
     // Un-debounce the onMapMove function for this test.
     jest.spyOn(require("lodash"), "debounce").mockImplementationOnce(fn => fn);
 
@@ -62,7 +63,7 @@ describe("MuseumSearchPage component", () => {
     });
   });
 
-  it("Passes the search query into child components.", async () => {
+  it("Passes the search query into child components.", () => {
     const mockRouter = {
       query: { q: "zoo" }
     };
@@ -72,5 +73,33 @@ describe("MuseumSearchPage component", () => {
 
     // The MuseumMap loaded dynamically, so it is selected as "LoadableComponent".
     expect(wrapper.find("LoadableComponent").prop("query")).toEqual("zoo");
+  });
+
+  it("Resizes the list container after the page mounts and after the window resizes.", () => {
+    (window.innerHeight as any) = 768;
+    const mockRouter = {
+      query: {}
+    };
+    const wrapper = mount(
+      <MockedProvider>
+        <MuseumSearchPage router={mockRouter as any} />
+      </MockedProvider>
+    );
+
+    const listContainer = wrapper.find(".list-container").getDOMNode();
+
+    // The list container's height should be the available space minus 1.
+    // (Page elements' heights above the list are ignored for the test.)
+    expect(listContainer.getAttribute("style")).toEqual(
+      "overflow-y: scroll; height: 767px;"
+    );
+
+    // Test a window resize:
+    (window.innerHeight as any) = 500;
+    window.onresize(null);
+
+    expect(listContainer.getAttribute("style")).toEqual(
+      "overflow-y: scroll; height: 499px;"
+    );
   });
 });

--- a/packages/client/pages/index.tsx
+++ b/packages/client/pages/index.tsx
@@ -24,8 +24,6 @@ const MUSEUMSEARCH_PAGE_CSS = `
     height: 100%;
   }
   #__next {
-    display: flex;
-    flex-flow: column;
     height: 100%;
   }
 `;
@@ -43,6 +41,8 @@ export class MuseumSearchPage extends React.Component<
 > {
   public state: IMuseumSearchPageState = {};
 
+  private listContainer: HTMLDivElement;
+
   private onMapMove = debounce<MoveHandler>(event => {
     const box = event.target.getBounds();
 
@@ -56,20 +56,35 @@ export class MuseumSearchPage extends React.Component<
     });
   }, 200);
 
+  public componentDidMount() {
+    const resizeListContainer = () => {
+      if (this.listContainer) {
+        const listHeight =
+          window.innerHeight -
+          this.listContainer.getBoundingClientRect().top -
+          1;
+        this.listContainer.style.height = `${listHeight}px`;
+      }
+    };
+
+    window.onresize = resizeListContainer;
+    resizeListContainer();
+  }
+
   public render() {
     const { router } = this.props;
     const { boundingBox } = this.state;
 
     return (
-      <div className="container-fluid p-0 d-flex flex-column flex-fill">
+      <div className="container-fluid">
         <style>{MUSEUMSEARCH_PAGE_CSS}</style>
         <Head title="Museum Search" />
-        <div className="flex-shrink-0">
-          <h1 className="col-12">Museum Search</h1>
+        <div>
+          <h1>Museum Search</h1>
         </div>
-        <div className="d-flex flex-row h-100">
-          <div className="d-flex flex-column flex-grow-1 card">
-            <div className="card-body flex-grow-0">
+        <div className="row">
+          <div className="col-md-3 p-0 card">
+            <div className="card-body">
               <Formik
                 initialValues={{ query: router.query.q }}
                 onSubmit={values => this.search({ q: values.query })}
@@ -84,7 +99,11 @@ export class MuseumSearchPage extends React.Component<
                 </Form>
               </Formik>
             </div>
-            <div style={{ overflowY: "scroll" }}>
+            <div
+              className="list-container"
+              ref={node => (this.listContainer = node)}
+              style={{ overflowY: "scroll" }}
+            >
               <MuseumList query={router.query.q || "museum"} />
             </div>
           </div>


### PR DESCRIPTION
-Changed the way the museum list is scrolled by moving from flex box
 to the equivalent javascript-based solution. The list container's
 height is now set when the page is mounted and when the window
 resizes, similar to how Google Maps works. This keeps the page
 layout's behavior consistent across browsers, working around
 inconsistent/unstable flex box support.