### PR TITLE
Feature: Sort museum list by geolocation.

### DIFF
--- a/packages/client/components/search/MuseumList.tsx
+++ b/packages/client/components/search/MuseumList.tsx
@@ -2,11 +2,21 @@ import gql from "graphql-tag";
 import { graphql } from "react-apollo";
 import { LoadingSpinner } from "../loading-spinner/LoadingSpinner";
 
+export interface ICoordinate {
+  latitude: number;
+  longitude: number;
+}
+
 /** MuseumList component props. */
 export interface IMuseumListProps {
   onItemHover: (hoveredItem: object) => void;
   onItemClick: (hoveredItem: object) => void;
+
+  /** Keyword search query. */
   query?: string;
+
+  /** Coordinate to sort by geo-distance. */
+  location?: ICoordinate;
 }
 
 /** MuseumList query response. */
@@ -17,12 +27,13 @@ interface IMuseumListResponse {
 /** MuseumList query variables. */
 interface IMuseumListVariables {
   query?: string;
+  location?: ICoordinate;
 }
 
 /** MuseumList query. */
 export const GET_MUSEUM_LIST = gql`
-  query($query: String) {
-    museums(query: $query, first: 50) {
+  query museumListQuery($query: String, $location: Coordinate) {
+    museums(query: $query, location: $location, first: 50) {
       edges {
         node {
           id
@@ -45,8 +56,9 @@ const withMuseumList = graphql<
   IMuseumListResponse,
   IMuseumListVariables
 >(GET_MUSEUM_LIST, {
-  options: ({ query }) => ({
+  options: ({ location, query }) => ({
     variables: {
+      location,
       query
     }
   })

--- a/packages/client/components/search/MuseumMap.tsx
+++ b/packages/client/components/search/MuseumMap.tsx
@@ -1,5 +1,5 @@
 import gql from "graphql-tag";
-import { divIcon, LatLngTuple, point } from "leaflet";
+import { divIcon, LatLngExpression, LatLngTuple, point } from "leaflet";
 import "leaflet/dist/leaflet.css";
 import { clamp } from "lodash";
 import React, { Ref } from "react";
@@ -12,6 +12,7 @@ export type MoveHandler = (box: IBoundingBox) => void;
 
 /** MuseumMap component props. */
 export interface IMuseumMapProps {
+  initialCenter: LatLngExpression;
   query?: string;
   boundingBox?: object;
   leafletMapRef?: Ref<Map>;
@@ -127,6 +128,7 @@ function redHighlightMarker(museum?: any) {
 export const MuseumMap = withMuseumMapObjects(function MuseumMapInternal({
   data: { loading, museumMapObjects },
   highlightedMuseum,
+  initialCenter,
   leafletMapRef,
   onMove
 }) {
@@ -155,7 +157,7 @@ export const MuseumMap = withMuseumMapObjects(function MuseumMapInternal({
         <LoadingSpinner loading={loading} />
       </div>
       <Map
-        center={[38.810338, -98.323266]}
+        center={initialCenter}
         className="h-100"
         onmove={onMoveInternal}
         ref={leafletMapRef}

--- a/packages/client/components/search/__tests__/MuseumList.test.tsx
+++ b/packages/client/components/search/__tests__/MuseumList.test.tsx
@@ -9,72 +9,78 @@ const DEFAULT_PROPS: IMuseumListProps = {
   onItemHover: () => undefined
 };
 
-const mocks: MockedResponse[] = [
+const MOCK_QUERY_RESULT = {
+  data: {
+    museums: {
+      __typename: "MuseumSearchConnection",
+      count: 99,
+      edges: [
+        {
+          __typename: "MuseumSearchEdge",
+          cursor: "13911",
+          node: {
+            __typename: "Museum",
+            city: null,
+            id: 13911,
+            latitude: 43.6555,
+            longitude: -70.26151,
+            name: "SPACE GALLERY",
+            state: null,
+            streetAddress: null
+          }
+        },
+        {
+          __typename: "MuseumSearchEdge",
+          cursor: "14897",
+          node: {
+            __typename: "Museum",
+            city: null,
+            id: 14897,
+            latitude: 42.26345,
+            longitude: -85.60829,
+            name: "SPACE GALLERY",
+            state: null,
+            streetAddress: null
+          }
+        },
+        {
+          __typename: "MuseumSearchEdge",
+          cursor: "16357",
+          node: {
+            __typename: "Museum",
+            city: "BONNE TERRE",
+            id: 16357,
+            latitude: 37.92174,
+            longitude: -90.55071,
+            name: "SPACE MUSEUM",
+            state: "MO",
+            streetAddress: "116 E SCHOOL ST"
+          }
+        }
+      ]
+    }
+  }
+};
+
+const DEFAULT_MOCKS: MockedResponse[] = [
+  // Success mock:
   {
     request: {
       query: GET_MUSEUM_LIST,
       variables: {
+        location: undefined,
         query: "space"
       }
     },
-    result: {
-      data: {
-        museums: {
-          __typename: "MuseumSearchConnection",
-          count: 99,
-          edges: [
-            {
-              __typename: "MuseumSearchEdge",
-              cursor: "13911",
-              node: {
-                __typename: "Museum",
-                city: null,
-                id: 13911,
-                latitude: 43.6555,
-                longitude: -70.26151,
-                name: "SPACE GALLERY",
-                state: null,
-                streetAddress: null
-              }
-            },
-            {
-              __typename: "MuseumSearchEdge",
-              cursor: "14897",
-              node: {
-                __typename: "Museum",
-                city: null,
-                id: 14897,
-                latitude: 42.26345,
-                longitude: -85.60829,
-                name: "SPACE GALLERY",
-                state: null,
-                streetAddress: null
-              }
-            },
-            {
-              __typename: "MuseumSearchEdge",
-              cursor: "16357",
-              node: {
-                __typename: "Museum",
-                city: "BONNE TERRE",
-                id: 16357,
-                latitude: 37.92174,
-                longitude: -90.55071,
-                name: "SPACE MUSEUM",
-                state: "MO",
-                streetAddress: "116 E SCHOOL ST"
-              }
-            }
-          ]
-        }
-      }
-    }
+    result: MOCK_QUERY_RESULT
   },
+  // Error mock:
   {
     error: new Error("An error happened!"),
     request: {
       query: GET_MUSEUM_LIST,
       variables: {
+        location: undefined,
         query: "Give me an error!"
       }
     }
@@ -83,7 +89,9 @@ const mocks: MockedResponse[] = [
 
 describe("MuseumList component", () => {
   function mountWithContext(element: JSX.Element) {
-    return mount(<MockedProvider mocks={mocks}>{element}</MockedProvider>);
+    return mount(
+      <MockedProvider mocks={DEFAULT_MOCKS}>{element}</MockedProvider>
+    );
   }
 
   it("Renders initially with a loading indicator.", async () => {
@@ -166,5 +174,41 @@ describe("MuseumList component", () => {
     expect(mockOnClick).lastCalledWith(
       expect.objectContaining({ name: "SPACE GALLERY" })
     );
+  });
+
+  it("Accepts a 'location' prop to sort by geo-distance.", async () => {
+    const mocks: MockedResponse[] = [
+      {
+        request: {
+          query: GET_MUSEUM_LIST,
+          variables: {
+            location: {
+              latitude: 39.6902721,
+              longitude: -98.2425472
+            },
+            query: undefined
+          }
+        },
+        result: MOCK_QUERY_RESULT
+      }
+    ];
+
+    const wrapper = mount(
+      <MockedProvider mocks={mocks}>
+        <MuseumList
+          {...DEFAULT_PROPS}
+          location={{
+            latitude: 39.6902721,
+            longitude: -98.2425472
+          }}
+        />
+      </MockedProvider>
+    );
+
+    await wait(2);
+    wrapper.update();
+
+    // Query should succeed with the location variable included.
+    expect(wrapper.find("li").length).toEqual(3);
   });
 });

--- a/packages/client/components/search/__tests__/MuseumMap.test.tsx
+++ b/packages/client/components/search/__tests__/MuseumMap.test.tsx
@@ -1,5 +1,6 @@
 import { InMemoryCache, IntrospectionFragmentMatcher } from "apollo-boost";
 import { mount } from "enzyme";
+import { LatLngExpression } from "leaflet";
 import { MockedProvider, MockedResponse } from "react-apollo/test-utils";
 import { Map, Marker } from "react-leaflet";
 import { fragmentTypes } from "../../../fragmentTypes";
@@ -66,6 +67,11 @@ const mocks: MockedResponse[] = [
   }
 ];
 
+const DEFAULT_PROPS = {
+  ...FLORIDA_SPACE_MUSEUM_VARIABLES,
+  initialCenter: [38.810338, -98.323266] as LatLngExpression
+};
+
 describe("MuseumMap component", () => {
   const { anything, objectContaining } = expect;
 
@@ -87,10 +93,8 @@ describe("MuseumMap component", () => {
   }
 
   it("Renders museum map objects.", async () => {
-    const wrapper = mountWithContext(
-      <MuseumMap {...FLORIDA_SPACE_MUSEUM_VARIABLES} />
-    );
-    await wait(0);
+    const wrapper = mountWithContext(<MuseumMap {...DEFAULT_PROPS} />);
+    await wait(2);
     wrapper.update();
 
     const markers = wrapper.find(Marker);
@@ -127,7 +131,7 @@ describe("MuseumMap component", () => {
     const onMove = jest.fn();
 
     const wrapper = mountWithContext(
-      <MuseumMap {...FLORIDA_SPACE_MUSEUM_VARIABLES} onMove={onMove} />
+      <MuseumMap {...DEFAULT_PROPS} onMove={onMove} />
     );
     await wait(0);
     wrapper.update();
@@ -158,7 +162,7 @@ describe("MuseumMap component", () => {
   it("Provides an optional onMove callback prop.", async () => {
     // Pass an undefined onMove prop.
     const wrapper = mountWithContext(
-      <MuseumMap {...FLORIDA_SPACE_MUSEUM_VARIABLES} onMove={undefined} />
+      <MuseumMap {...DEFAULT_PROPS} onMove={undefined} />
     );
     await wait(0);
     wrapper.update();
@@ -184,6 +188,7 @@ describe("MuseumMap component", () => {
   it("Provides a highlightedMarker prop to show a highlighted marker.", () => {
     const wrapper = mountWithContext(
       <MuseumMap
+        {...DEFAULT_PROPS}
         highlightedMuseum={mocks[0].result.data.museumMapObjects.edges[2].node}
       />
     );
@@ -200,7 +205,7 @@ describe("MuseumMap component", () => {
     const onMove = jest.fn();
 
     const wrapper = mountWithContext(
-      <MuseumMap {...FLORIDA_SPACE_MUSEUM_VARIABLES} onMove={onMove} />
+      <MuseumMap {...DEFAULT_PROPS} onMove={onMove} />
     );
     await wait(0);
     wrapper.update();
@@ -255,11 +260,21 @@ describe("MuseumMap component", () => {
 
     mountWithContext(
       <MuseumMap
-        {...FLORIDA_SPACE_MUSEUM_VARIABLES}
+        {...DEFAULT_PROPS}
         leafletMapRef={node => (refWrapper.leafletMapRef = node)}
       />
     );
 
     expect(refWrapper.leafletMapRef.leafletElement).toBeTruthy();
+  });
+
+  it("Accepts an 'initialCenter' prop to set the initial center of the Leaflet Map.", () => {
+    const initialCenter: LatLngExpression = [41.1235368, -107.2246636];
+
+    const wrapper = mountWithContext(
+      <MuseumMap {...DEFAULT_PROPS} initialCenter={initialCenter} />
+    );
+
+    expect(wrapper.find(Map).prop("center")).toBe(initialCenter);
   });
 });

--- a/packages/client/page-tests/__tests__/index.test.tsx
+++ b/packages/client/page-tests/__tests__/index.test.tsx
@@ -171,6 +171,48 @@ describe("MuseumSearchPage component", () => {
         .onItemClick(testMuseum);
     });
 
-    expect(flyToSpy).lastCalledWith([37.750982, -85.363281], 15);
+    expect(flyToSpy).lastCalledWith([37.750982, -85.363281], 15, {
+      duration: 1
+    });
+  });
+
+  it("Passes a default location prop to the MuseumList.", () => {
+    const wrapper = mount(
+      <MockedProvider>
+        <MuseumSearchPage router={MOCK_ROUTER} />
+      </MockedProvider>
+    );
+
+    expect(wrapper.find(MuseumList).prop("location")).toEqual({
+      latitude: 38.810338,
+      longitude: -98.323266
+    });
+  });
+
+  it("Changes the MuseumList's 'location' prop when the map is moved.", () => {
+    // Un-debounce the onMapMove function for this test.
+    jest.spyOn(require("lodash"), "debounce").mockImplementationOnce(fn => fn);
+
+    const wrapper = mount(
+      <MockedProvider>
+        <MuseumSearchPage router={MOCK_ROUTER} />
+      </MockedProvider>
+    );
+
+    act(() => {
+      wrapper.find(MuseumMap).prop("onMove")({
+        bottom: 3,
+        left: 2,
+        right: 4,
+        top: 1
+      });
+    });
+
+    wrapper.update();
+
+    expect(wrapper.find(MuseumList).prop("location")).toEqual({
+      latitude: 2,
+      longitude: 3
+    });
   });
 });

--- a/packages/server/src/graphql-api/resolvers/__tests__/__snapshots__/museumMapObjects.test.ts.snap
+++ b/packages/server/src/graphql-api/resolvers/__tests__/__snapshots__/museumMapObjects.test.ts.snap
@@ -169,10 +169,7 @@ Array [
         },
       },
       "query": Object {
-        "bool": Object {
-          "filter": undefined,
-          "must": undefined,
-        },
+        "bool": Object {},
       },
     },
     "index": "museums",
@@ -187,9 +184,7 @@ Array [
     "body": Object {
       "query": Object {
         "bool": Object {
-          "filter": undefined,
           "minimum_should_match": 1,
-          "must": undefined,
           "should": Array [
             Object {
               "bool": Object {
@@ -296,7 +291,6 @@ Array [
               },
             },
           },
-          "must": undefined,
         },
       },
     },

--- a/packages/server/src/graphql-api/resolvers/__tests__/__snapshots__/museums.test.ts.snap
+++ b/packages/server/src/graphql-api/resolvers/__tests__/__snapshots__/museums.test.ts.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`museums query returns a MuseumConnection 1`] = `
+exports[`museums query Returns a MuseumSearchConnection 1`] = `
 Object {
   "data": Object {
     "museums": Object {

--- a/packages/server/src/graphql-api/resolvers/museumMapObjects.ts
+++ b/packages/server/src/graphql-api/resolvers/museumMapObjects.ts
@@ -71,21 +71,21 @@ async function getMuseumBuckets({
       },
       query: {
         bool: {
-          filter: boundingBox
-            ? {
-                geo_bounding_box: {
-                  location: boundingBox
-                }
+          ...(boundingBox && {
+            filter: {
+              geo_bounding_box: {
+                location: boundingBox
               }
-            : undefined,
-          must: query
-            ? {
-                multi_match: {
-                  operator: "and",
-                  query
-                }
+            }
+          }),
+          ...(query && {
+            must: {
+              multi_match: {
+                operator: "and",
+                query
               }
-            : undefined
+            }
+          })
         }
       }
     },
@@ -175,22 +175,22 @@ async function getMuseumHits({
     body: {
       query: {
         bool: {
-          filter: boundingBox
-            ? {
-                geo_bounding_box: {
-                  location: boundingBox
-                }
+          ...(boundingBox && {
+            filter: {
+              geo_bounding_box: {
+                location: boundingBox
               }
-            : undefined,
+            }
+          }),
           minimum_should_match: 1,
-          must: query
-            ? {
-                multi_match: {
-                  operator: "and",
-                  query
-                }
+          ...(query && {
+            must: {
+              multi_match: {
+                operator: "and",
+                query
               }
-            : undefined,
+            }
+          }),
           should: boundingBoxesToUnpack.map(box => ({
             bool: {
               filter: {

--- a/packages/server/src/graphql-api/resolvers/museums.ts
+++ b/packages/server/src/graphql-api/resolvers/museums.ts
@@ -3,7 +3,7 @@ import { IResolverContext } from "../types";
 
 export const museums: IFieldResolver<{}, IResolverContext> = async (
   _,
-  { first, query },
+  { first, location, query },
   { esClient }
 ) => {
   const { hits } = await esClient.search({
@@ -13,7 +13,19 @@ export const museums: IFieldResolver<{}, IResolverContext> = async (
           operator: "and",
           query
         }
-      }
+      },
+      ...(location && {
+        sort: [
+          {
+            _geo_distance: {
+              location: {
+                lat: location.latitude,
+                lon: location.longitude
+              }
+            }
+          }
+        ]
+      })
     },
     index: "museums",
     size: first

--- a/packages/server/src/graphql-api/typeDefs.ts
+++ b/packages/server/src/graphql-api/typeDefs.ts
@@ -5,7 +5,11 @@ import { gql } from "apollo-server";
  */
 export const typeDefs = gql`
   type Query {
-    museums(query: String, first: Int!): MuseumSearchConnection
+    museums(
+      query: String
+      location: Coordinate
+      first: Int!
+    ): MuseumSearchConnection
     museumMapObjects(
       query: String
       boundingBox: GeoBoundingBoxInput
@@ -36,6 +40,11 @@ export const typeDefs = gql`
   type MuseumSearchConnection {
     edges: [MuseumSearchEdge]
     count: Int
+  }
+
+  input Coordinate {
+    latitude: Float!
+    longitude: Float!
   }
 
   input GeoBoundingBoxInput {


### PR DESCRIPTION
-Added optional "location" param to "museums" resolver.
-Museum list is now sorted by geo distance from the map's center point.
-Increased the map's flyTo speed from default (slow) to 1 second.